### PR TITLE
lua: guideline update according to #3222

### DIFF
--- a/lua-guidelines.md
+++ b/lua-guidelines.md
@@ -827,6 +827,9 @@ http://en.wikipedia.org/wiki/Magic_number_(programming)#Unnamed_numerical_consta
 
 ###Тестовые значения и сообщения об ошибках
 
+Рекомендуется вместо `assert(condition)` использовать высокоуровневые функции из
+`lua-nucleo`, напр. `ensure(success_message, condition)`.
+
 Для тестовых строковых значений рекомендуется использовать что-нибудь всем
 хорошо знакомое, например "Lorem ipsum...".
 


### PR DESCRIPTION
A call to stop using plain asserts in favor of ensure\* helpers.
Please, consider applying
